### PR TITLE
Add config auto_generate_type

### DIFF
--- a/lib/generators/schemate/templates/schemate.rb
+++ b/lib/generators/schemate/templates/schemate.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 Schemate.configure do |config|
   config.auto_generate = false
+  config.auto_generate_type = 'md'
 end

--- a/lib/schemate/config.rb
+++ b/lib/schemate/config.rb
@@ -11,9 +11,11 @@ module Schemate
   class Configuration
     include ActiveSupport::Configurable
     config_accessor :auto_generate
+    config_accessor :auto_generate_type
   end
 
   configure do |config|
     config.auto_generate = false
+    config.auto_generate_type = 'md'
   end
 end

--- a/lib/tasks/schemate_migrate.rake
+++ b/lib/tasks/schemate_migrate.rake
@@ -3,13 +3,21 @@ require "schemate/config"
 namespace :db do
   [:migrate, :rollback].each do |cmd|
     task cmd do
-      Rake::Task['schemate:export_md'].invoke if Schemate.config.auto_generate
+      if Schemate.config.auto_generate_type == 'md'
+        Rake::Task['schemate:export_md'].invoke if Schemate.config.auto_generate
+      elsif Schemate.config.auto_generate_type == 'csv'
+        Rake::Task['schemate:export_csv'].invoke if Schemate.config.auto_generate
+      end
     end
 
     namespace cmd do
       [:change, :up, :down, :reset, :redo].each do |t|
         task t do
-          Rake::Task['schemate:export_md'].invoke if Schemate.config.auto_generate
+          if Schemate.config.auto_generate_type == 'md'
+            Rake::Task['schemate:export_md'].invoke if Schemate.config.auto_generate
+          elsif Schemate.config.auto_generate_type == 'csv'
+            Rake::Task['schemate:export_csv'].invoke if Schemate.config.auto_generate
+          end
         end
       end
     end


### PR DESCRIPTION
I added auto_generate_type to config.
When ```auto_generate_type = 'md'``` , generate a markdown file.
When ```auto_generate_type = 'csv'``` , generate a csv file.